### PR TITLE
Fix the UI of the cta and hero section

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -57,6 +57,7 @@ a {
     display: flex;
     flex-direction: column;
     gap: 10px;
+
 }
 
 .hero-main-text {
@@ -67,6 +68,7 @@ a {
 .hero-secondary-text {
     font-size: 18px;
     color: #E5E7EB;
+    margin: 20px 0px;
 }
 
 .hero-signup {
@@ -75,8 +77,10 @@ a {
     color: #F9FAF8;
     font-size: 18px;
     border-radius: 7px;
-    padding: 5px 25px;
-    width: 35%;
+    padding: 10px 20px;
+    width: 125px;
+    cursor: pointer;
+
 }
 
 .hero-image {
@@ -169,6 +173,7 @@ h1 {
     padding: 50px;
     border-radius: 15px;
     justify-content: space-between;
+
 }
 
 .cta-head {
@@ -178,6 +183,7 @@ h1 {
 
 .cta-text {
     font-size: 20px;
+
 }
 
 .cta-signup {
@@ -187,6 +193,8 @@ h1 {
     font-size: 18px;
     border-radius: 7px;
     padding: 5px 25px;
+    align-self: flex-end;
+    cursor: pointer;
 }
 
 /* Footer */


### PR DESCRIPTION
I changed the positioning of the `Sign Up` button in the `cta` section to align at the bottom, in the same line as the bottom text for a better UI.

I fixed the `hero` read me section by adding some space between the text and the button, and also fixed the width and height of the `Sign Up` button.

Also changed the `cursor` to the both buttons to be to pointer so the user can tell it's clickable.

Below are the `before` and `after` videos:

`BEFORE`:

https://user-images.githubusercontent.com/94648837/198873890-c4bc10fc-376a-428e-a35a-266d7129dd3a.mov


`AFTER`:

https://user-images.githubusercontent.com/94648837/198873909-08339fa7-52f0-4abf-a00d-16abe622d47e.mov

